### PR TITLE
Made the hacktoberfirst button go to the hacktoberfirst website.

### DIFF
--- a/events/past-events.html
+++ b/events/past-events.html
@@ -127,7 +127,7 @@
             GitHub and Twilio.</p>
         </div>
         <div class="card-footer bg-white text-center">
-          <a href="#" class="btn btn-outline-warning">View Event</a>
+          <a href="https://hacktoberfest.digitalocean.com/" target="_blank" class="btn btn-outline-warning">View Event</a>
         </div>
       </div>
 


### PR DESCRIPTION
Hey, I changed the hacktoberfirst button on the past-events page go to the hacktoberfirst website. Cool?