### PR TITLE
Changed .text-style (650px -> 650vw) for web responsiveness

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -242,7 +242,7 @@ div.desktop-wrapper iframe {
 }
 
 .text-style {
-  width: 650px;
+  width: 650vw;
 }
 
 .noBullets {


### PR DESCRIPTION
Course descriptions would bulge out the right side when on mobile. I changed the unit from "px" to "vw"