### PR TITLE
Updated .nav-link (&:hover) style for cleaner background and spacing

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -83,15 +83,19 @@ When adding styles try to ensure the following:
 
 .nav-link {
     text-transform: uppercase;
+    margin: 0 5px;
 }
 
-.navbar-nav li:hover,
-.nav-item a:hover {
+.navbar-nav li:hover {
     background-color: #888;
-    color: #d4af37 !important;
     border-radius: 5px;
     transition: all 0.3s ease-in-out;
     transform: translateY(-1px);
+}
+
+.nav-item a:hover {
+    color: #d4af37 !important;
+    transition: all 0.3s ease-in-out;
 }
 
 .dropdown-menu,


### PR DESCRIPTION
Hi Z-M! In my first contribution to be part of the open source community, I have done the following:

1. UPDATE: navbar links' hover effect was adding a background to both the 'li' and the 'a' tags. Now it will only add to the 'li' tag.

2. UPDATE: some space has been added to the navbar links ('li') for an easier read.  => **margin: 0 5px;**

Hope the changes are acceptable. Thanks for all that you do!