### PR TITLE
Update 2018 dates to 2019 for Zero-to-Mastery course card and in the …

### DIFF
--- a/index.html
+++ b/index.html
@@ -385,10 +385,10 @@
 
         <!-- Description -->
         <p>
-          <em>"The Complete Web Developer in 2018: Zero to Mastery"</em> is a
+          <em>"The Complete Web Developer in 2019: Zero to Mastery"</em> is a
           complete full-stack web development course, with the latest and most
           in-demand technologies, for anyone trying to learn web development in
-          2018.
+          2019.
           <br />
           <br />
           Learn to code with us, join the community and practice the skills you
@@ -410,10 +410,10 @@
           />
           <div class="card-body">
             <h5 class="card-title">
-              The Complete Web Developer in 2018: Zero to Mastery
+              The Complete Web Developer in 2019: Zero to Mastery
             </h5>
             <p class="card-text">
-              Learn to code and become a web developer in 2018 with HTML5, CSS,
+              Learn to code and become a web developer in 2019 with HTML5, CSS,
               Javascript, React, Node.js, Machine Learning & more!
             </p>
           </div>


### PR DESCRIPTION
I noticed that the dates was still set to 2018 for the Zero-to-Mastery course card and the description below the video on the main page of the site. I updated them to say 2019 to match the course on Udemy as well as the actual course page on the website. 