### PR TITLE
added link for GeeksforGeeks website 

### DIFF
--- a/community/resources.html
+++ b/community/resources.html
@@ -126,6 +126,7 @@
             <li><a href="https://caniuse.com/" target="_blank" rel="noopener noreferrer">Can I Use?</a></li>
             <li><a href="https://codepen.io/" target="_blank" rel="noopener noreferrer">Codepen</a></li>
             <li><a href="https://devdocs.io/" target="_blank" rel="noopener noreferrer">Devdocs</a></li>
+            <li><a href="https://www.geeksforgeeks.org/" target="_blank" rel="noopener noreferrer">GeeksforGeeks</a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
A link to GeeksforGeeks website was added on the resources page. It can be found at Community > Handy Resources > General Resources.